### PR TITLE
Fixed a bug where the undead could not be triggered

### DIFF
--- a/scenarios/11_Returning_to_Home.cfg
+++ b/scenarios/11_Returning_to_Home.cfg
@@ -386,6 +386,15 @@
             side=2
             x,y=2,27
         [/capture_village]
+
+        [set_variable]
+            name=door_opened_34_25
+            value=0
+        [/set_variable]
+        [set_variable]
+            name=door_opened_34_17
+            value=0
+        [/set_variable]
     [/event]
 
     [event]


### PR DESCRIPTION
Stumbled across this bug while playing the last scenario and it's annoying because you cannot finish the scenario without triggering the undead.
Feel free to adjust the fix to your code style! I'm not an experienced WML coder.